### PR TITLE
fix bug fill-in-the-blank incorrectly wrong

### DIFF
--- a/src/utils/fillInTheBlanks.js
+++ b/src/utils/fillInTheBlanks.js
@@ -67,9 +67,13 @@ export const splitSentence = (text = '', response = '') => {
 };
 
 export const responseToText = (response) => {
-  return response.reduce((acc, word) => {
-    const text =
-      word.type === FILL_BLANKS_TYPE.BLANK ? `<${word.displayed}>` : word.text;
-    return acc + ' ' + text;
-  }, '');
+  return response
+    .reduce((acc, word) => {
+      const text =
+        word.type === FILL_BLANKS_TYPE.BLANK
+          ? `<${word.displayed}>`
+          : word.text;
+      return acc + ' ' + text;
+    }, '')
+    .trim();
 };


### PR DESCRIPTION
Fix the bug for `Fill in the blank` question type.

The bug was that we had a white space in front of the reconstructed sentence, so it was not matching the original sentence that had not this white space in front, and therefore was always marked as wrong.

![Screenshot from 2023-03-16 15-14-36](https://user-images.githubusercontent.com/56824395/225645304-85ad82fd-df0c-458f-9e6d-908cacf3385b.png)
