### PR TITLE
fix: show only current member data in playview

### DIFF
--- a/cypress/e2e/legacy.cy.ts
+++ b/cypress/e2e/legacy.cy.ts
@@ -59,7 +59,8 @@ describe('Legacy', () => {
     };
 
     const item = { id: 'mock-item-id' };
-    const member = { id: 'mock-member-id-1', name: 'liam' };
+    // current user
+    const member = { id: 'mock-member-id', name: 'liam' };
     const appData = [
       {
         item,

--- a/cypress/e2e/play/playView.cy.js
+++ b/cypress/e2e/play/playView.cy.js
@@ -1,13 +1,16 @@
 import { PermissionLevel } from '@graasp/sdk';
 
 import {
+  EXPLANATION_PLAY_CY,
   PLAY_VIEW_EMPTY_QUIZ_CY,
   PLAY_VIEW_QUESTION_TITLE_CY,
   QUESTION_BAR_CY,
   QUESTION_BAR_NEXT_CY,
   QUESTION_BAR_PREV_CY,
+  buildQuestionStepCy,
   dataCyWrapper,
 } from '../../../src/config/selectors';
+import { LIAM_RESPONSES } from '../../fixtures/appData';
 import { APP_SETTINGS } from '../../fixtures/appSettings';
 
 describe('Play View', () => {
@@ -20,6 +23,33 @@ describe('Play View', () => {
     cy.visit('/');
 
     cy.get(dataCyWrapper(PLAY_VIEW_EMPTY_QUIZ_CY)).should('be.visible');
+  });
+
+  it('Show nothing even if receive other users data', () => {
+    cy.setUpApi({
+      database: {
+        appSettings: APP_SETTINGS,
+        appData: LIAM_RESPONSES, // app data but not the current user's
+      },
+    });
+    cy.visit('/');
+
+    cy.get(`${dataCyWrapper(PLAY_VIEW_QUESTION_TITLE_CY)}`).should(
+      'contain',
+      APP_SETTINGS[0].data.question
+    );
+
+    // should not display app data
+    cy.get(
+      `${dataCyWrapper(
+        buildQuestionStepCy(APP_SETTINGS[0].data.questionId)
+      )} svg`
+    ).then(($el) => {
+      expect($el.attr('class').toLowerCase()).not.to.contain('error');
+      expect($el.attr('class').toLowerCase()).not.to.contain('success');
+    });
+
+    cy.get(`${dataCyWrapper(EXPLANATION_PLAY_CY)}`).should('not.exist');
   });
 
   describe('Play View', () => {

--- a/src/components/context/utilities.ts
+++ b/src/components/context/utilities.ts
@@ -84,7 +84,7 @@ export const computeCorrectness = (
 };
 
 export const getAppDataByQuestionIdForMemberId = (
-  appData: List<AppDataQuestionRecord> = List(),
+  appData: List<AppDataQuestionRecord>,
   question: QuestionDataAppSettingRecord,
   memberId?: Member['id']
 ) => {
@@ -134,10 +134,10 @@ export const getAllAppDataByUserId = (
 
 export const areTagsMatching = (text: string) => {
   let acc = 0;
-  for (let i = 0; i < text.length; i++) {
-    if (text[i] === '<') {
+  for (const element of text) {
+    if (element === '<') {
       acc += 1;
-    } else if (text[i] === '>') {
+    } else if (element === '>') {
       acc -= 1;
     }
 

--- a/src/components/context/utilities.ts
+++ b/src/components/context/utilities.ts
@@ -1,7 +1,7 @@
 import { List } from 'immutable';
 import { v4 as uuidv4 } from 'uuid';
 
-import { convertJs } from '@graasp/sdk';
+import { Member, convertJs } from '@graasp/sdk';
 import { AppDataRecord, AppSettingRecord } from '@graasp/sdk/frontend';
 
 import {
@@ -83,19 +83,28 @@ export const computeCorrectness = (
   }
 };
 
-export const getAppDataByQuestionId = (
+export const getAppDataByQuestionIdForMemberId = (
   appData: List<AppDataQuestionRecord> = List(),
-  question: QuestionDataAppSettingRecord
-): AppDataRecord => {
+  question: QuestionDataAppSettingRecord,
+  memberId?: Member['id']
+) => {
   const qId = question.data.questionId;
+  const defaultValue = convertJs({
+    data: {
+      questionId: qId,
+      ...DEFAULT_APP_DATA_VALUES[question.data.type],
+    },
+  });
+
+  if (!memberId) {
+    return defaultValue;
+  }
+
   return (
-    appData?.find(({ data }) => data?.questionId === qId) ??
-    convertJs({
-      data: {
-        questionId: qId,
-        ...DEFAULT_APP_DATA_VALUES[question.data.type],
-      },
-    })
+    appData?.find(
+      ({ data, creator }) =>
+        data?.questionId === qId && creator?.id === memberId
+    ) ?? defaultValue
   );
 };
 

--- a/src/components/navigation/QuestionTopBar.tsx
+++ b/src/components/navigation/QuestionTopBar.tsx
@@ -29,7 +29,7 @@ import {
 import { QuizContext } from '../context/QuizContext';
 import {
   computeCorrectness,
-  getAppDataByQuestionId,
+  getAppDataByQuestionIdForMemberId,
   getQuestionById,
 } from '../context/utilities';
 import {
@@ -50,6 +50,7 @@ const QuestionTopBar = () => {
   } = useContext(QuizContext);
   const context = useLocalContext();
   const { data: appData, isLoading } = hooks.useAppData();
+  const { memberId } = useLocalContext();
 
   if (isLoading) {
     return <Skeleton variant="rectangular" width="100%" height={70} />;
@@ -61,9 +62,10 @@ const QuestionTopBar = () => {
       console.error('question does not exist');
       return null;
     }
-    const response = getAppDataByQuestionId(
+    const response = getAppDataByQuestionIdForMemberId(
       (appData as List<AppDataQuestionRecord>) ?? List(),
-      q
+      q,
+      memberId
     );
     const question = getQuestionById(questions, questionId);
 

--- a/src/components/play/PlayView.tsx
+++ b/src/components/play/PlayView.tsx
@@ -42,7 +42,7 @@ const PlayView = () => {
 
   const [newResponse, setNewResponse] = useState<AppDataRecord>(
     getAppDataByQuestionIdForMemberId(
-      responses as List<AppDataQuestionRecord>,
+      (responses as List<AppDataQuestionRecord>) ?? List(),
       currentQuestion,
       memberId
     )

--- a/src/components/play/PlayView.tsx
+++ b/src/components/play/PlayView.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Alert, Button, Grid, Typography } from '@mui/material';
 
+import { useLocalContext } from '@graasp/apps-query-client';
 import { AppDataRecord } from '@graasp/sdk/frontend';
 
 import { APP_DATA_TYPES, QuestionType } from '../../config/constants';
@@ -16,7 +17,7 @@ import {
   PLAY_VIEW_SUBMIT_BUTTON_CY,
 } from '../../config/selectors';
 import { QuizContext } from '../context/QuizContext';
-import { getAppDataByQuestionId } from '../context/utilities';
+import { getAppDataByQuestionIdForMemberId } from '../context/utilities';
 import QuestionTopBar from '../navigation/QuestionTopBar';
 import {
   AppDataQuestionRecord,
@@ -35,13 +36,15 @@ const PlayView = () => {
   const { mutate: patchAppData } = mutations.usePatchAppData();
 
   const { currentQuestion, questions } = useContext(QuizContext);
+  const { memberId } = useLocalContext();
 
   const [showCorrection, setShowCorrection] = React.useState(false);
 
   const [newResponse, setNewResponse] = useState<AppDataRecord>(
-    getAppDataByQuestionId(
+    getAppDataByQuestionIdForMemberId(
       responses as List<AppDataQuestionRecord>,
-      currentQuestion
+      currentQuestion,
+      memberId
     )
   );
 
@@ -49,9 +52,10 @@ const PlayView = () => {
     if (responses && currentQuestion) {
       // assume there's only one response for a question
       setNewResponse(
-        getAppDataByQuestionId(
+        getAppDataByQuestionIdForMemberId(
           responses as List<AppDataQuestionRecord>,
-          currentQuestion
+          currentQuestion,
+          memberId
         )
       );
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17709,14 +17709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.1, tslib@npm:^2.5.0":
-  version: 2.6.2
-  resolution: "tslib@npm:2.6.2"
-  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.4.1 || ^1.9.3":
+"tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.1, tslib@npm:^2.4.1 || ^1.9.3, tslib@npm:^2.5.0":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad


### PR DESCRIPTION
In Player, the app was showing data even though I didn't answer to them. It was because as admin I have access to lots of app data and the first ones were showing. 

The fix filter over the creator of the app data.

close #88 